### PR TITLE
Add Alternative Methods for Obtaining Public IP Address

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -19,3 +19,14 @@ alias week='date +%V'
 # IP Addresses
 alias local-ip='hostname -I'
 alias public-ip='dig ANY +short @resolver2.opendns.com myip.opendns.com'
+
+# --- alternative ways to get public IP ---
+# Uncomment one of the following aliases to use an alternative method to get the public IP address:
+# - The first one returns the IP address in the format: "192.168.1.1"
+# - The second one parses it to get only the IP: 192.168.1.1
+#
+# alias public-ip='dig TXT +short o-o.myaddr.l.google.com @ns1.google.com'
+# alias public-ip="dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | awk -F'\"' '{ print \$2}'"
+#
+# alias public-ip='dig +short txt ch whoami.cloudflare @1.0.0.1'
+# alias public-ip="dig +short txt ch whoami.cloudflare @1.0.0.1 | awk -F'\"' '{ print \$2}'"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # dotfiles
+
+
+
+## Configuration
+When installing the dotfiles, the following functionality is added:
+- Clipboard actions | pbcopy, pbpaste
+- Directory navigation | .., ..., ...., home, root
+- public-ip & local-ip | Get your public and local IP
+- week | current week number
+
+
+
+## Stow
+This command will create symlinks for the files in the current directory to the parent directory.
+```bash
+stow .
+```


### PR DESCRIPTION
This PR introduces additional aliases in `.bash_aliases` to provide alternative methods for fetching the public IP address. Users can
choose between different DNS-based methods to suit their network environment or preference.